### PR TITLE
Fix if condition in LoginSerializer

### DIFF
--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -100,7 +100,7 @@ class LoginSerializer(serializers.Serializer):
             raise exceptions.ValidationError(msg)
 
         # If required, is the email verified?
-        if 'rest_auth.registration' in settings.INSTALLED_APPS:
+        if 'dj_rest_auth.registration' in settings.INSTALLED_APPS:
             from allauth.account import app_settings
             if app_settings.EMAIL_VERIFICATION == app_settings.EmailVerificationMethod.MANDATORY:
                 email_address = user.emailaddress_set.get(email=user.email)


### PR DESCRIPTION
As there is no reference to 'rest_auth.registration' this condition always validates to False.
We should check if 'dj_rest_auth.registration' is in INSTALLED_APPS.