### PR TITLE
Uncomment 'django.contrib.messages'

### DIFF
--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -31,7 +31,7 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
-    # 'django.contrib.messages',
+    'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sites',
 


### PR DESCRIPTION
When run  'python manage.py migrate --settings=demo.settings --noinput'

I get this on console
SystemCheckError: System check identified some issues:

ERRORS:
?: (admin.E406) 'django.contrib.messages' must be in INSTALLED_APPS in order to use the admin application.

So uncomment it to solve the issue.