### PR TITLE
Fix AttributeError at /docs/

### DIFF
--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -120,7 +120,8 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
-    )
+    ),
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema'
 }
 
 SWAGGER_SETTINGS = {


### PR DESCRIPTION
Using this solution https://github.com/encode/django-rest-framework/issues/6809#issuecomment-546302742

To fix:
AttributeError at /docs/
'AutoSchema' object has no attribute 'get_link'