### PR TITLE
Note in docs to add allauth urls if account email verification is man…

### DIFF
--- a/docs/api_endpoints.rst
+++ b/docs/api_endpoints.rst
@@ -62,8 +62,8 @@ Registration
     - key
 
     .. note:: If you set account email verification as mandatory, you have to add the VerifyEmailView with the used `name`.
-        You need to import the view: ``from rest_auth.registration.views import VerifyEmailView``. Then add the url with the corresponding name:
-        ``url(r'^rest-auth/account-confirm-email/', VerifyEmailView.as_view(), name='account_email_verification_sent')`` to the urlpatterns list.
+        You need to import the view: ``from dj_rest_auth.registration.views import VerifyEmailView``. Then add the url with the corresponding name:
+        ``url(r'^dj-rest-auth/account-confirm-email/', VerifyEmailView.as_view(), name='account_email_verification_sent')`` to the urlpatterns list.
         
 
 

--- a/docs/api_endpoints.rst
+++ b/docs/api_endpoints.rst
@@ -61,6 +61,11 @@ Registration
 
     - key
 
+    .. note:: If you set account email verification as mandatory, you have to add the VerifyEmailView with the used `name`.
+        You need to import the view: ``from rest_auth.registration.views import VerifyEmailView``. Then add the url with the corresponding name:
+        ``url(r'^rest-auth/account-confirm-email/', VerifyEmailView.as_view(), name='account_email_verification_sent')`` to the urlpatterns list.
+        
+
 
 Social Media Authentication
 ---------------------------


### PR DESCRIPTION
…datory

Update docs to add `account_email_verification_sent` endpoint while using `registration`.

Without this endpoint, if email verification is set to **MANDATORY** , it gives error
```
Reverse for 'account_email_verification_sent' not found. 'account_email_verification_sent' is not a valid view function or pattern name.
```

This is a copy PR of [#577](https://github.com/Tivix/django-rest-auth/pull/577) in in upstream project.