### PR TITLE
Skip old_password validation when user has no usable password set

### DIFF
--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -239,11 +239,12 @@ class PasswordChangeSerializer(serializers.Serializer):
         )
         super(PasswordChangeSerializer, self).__init__(*args, **kwargs)
 
-        if not self.old_password_field_enabled:
-            self.fields.pop('old_password')
-
         self.request = self.context.get('request')
         self.user = getattr(self.request, 'user', None)
+        
+        if not self.old_password_field_enabled or not self.user.has_usable_password():
+            self.fields.pop('old_password')
+
 
     def validate_old_password(self, value):
         invalid_password_conditions = (


### PR DESCRIPTION
In case of social authentication, an unusable password is set.

If settings have `OLD_PASSWORD_FIELD_ENABLED` then `old_password` is validated when the user changes the password.
Since the user has not set any password in the past, the check for `old_password` should be skipped to change the password.

The validation will work when the user has a password set.