### PR TITLE
Refresh token not blacklisted on logout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# IDE
+.idea
+
 # pyenv
 .python-version
 

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-test:
-	coverage run --source=dj_rest_auth setup.py test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	coverage run --source=dj_rest_auth setup.py test

--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ REST_USE_JWT = True
 JWT_AUTH_COOKIE = 'jwt-auth'
 ```
 
+### Testing
 
+To run the tests within a virtualenv, run `python runtests.py` from the repository directory.
+The easiest way to run test coverage is with [`coverage`](https://pypi.org/project/coverage/),
+which runs the tests against all supported Django installs. To run the test coverage 
+within a virtualenv, run `coverage run ./runtests.py` from the repository directory then run `coverage report`.
 
 
 ### Documentation

--- a/dj_rest_auth/tests/settings.py
+++ b/dj_rest_auth/tests/settings.py
@@ -94,6 +94,8 @@ INSTALLED_APPS = [
 
     'dj_rest_auth',
     'dj_rest_auth.registration',
+
+    'rest_framework_simplejwt.token_blacklist'
 ]
 
 SECRET_KEY = "38dh*skf8sjfhs287dh&^hd8&3hdg*j2&sd"

--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -555,3 +555,14 @@ class APIBasicTests(TestsMixin, TestCase):
         self.assertEqual(['jwt-auth'], list(resp.cookies.keys()))
         resp = self.get('/protected-view/')
         self.assertEquals(resp.status_code, 200)
+
+    @override_settings(REST_USE_JWT=True)
+    def test_blacklisting(self):
+        payload = {
+            "username": self.USERNAME,
+            "password": self.PASS
+        }
+        get_user_model().objects.create_user(self.USERNAME, '', self.PASS)
+        self.post(self.login_url, data=payload, status_code=200)
+        resp = self.post(self.logout_url, status=200)
+        pass

--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -583,13 +583,18 @@ class APIBasicTests(TestsMixin, TestCase):
         get_user_model().objects.create_user(self.USERNAME, '', self.PASS)
         resp = self.post(self.login_url, data=payload, status_code=200)
         token = resp.data['refresh_token']
+        # test refresh token not included in request data
         resp = self.post(self.logout_url, status=200)
         self.assertEqual(resp.status_code, 401)
+        # test token is invalid or expired
         resp = self.post(self.logout_url, status=200, data={'refresh': '1'})
-        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.status_code, 401)
+        # test successful logout
         resp = self.post(self.logout_url, status=200, data={'refresh': token})
         self.assertEqual(resp.status_code, 200)
+        # test token is blacklisted
         resp = self.post(self.logout_url, status=200, data={'refresh': token})
-        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.status_code, 401)
+        # test other TokenError, AttributeError, TypeError (invalid format)
         resp = self.post(self.logout_url, status=200, data=json.dumps({'refresh': token}))
         self.assertEqual(resp.status_code, 500)

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -142,20 +142,20 @@ class LogoutView(APIView):
             cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
             if cookie_name:
                 response.delete_cookie(cookie_name)
-            # add refresh token to blacklist
-            try:
-                token = RefreshToken(request.data['refresh'])
-                token.blacklist()
-            except KeyError:
-                response = Response({"detail": _("Refresh token was not included.")},
-                                    status=status.HTTP_401_UNAUTHORIZED)
-            except TokenError as e:
-                if e.args[0] == 'Token is blacklisted':
-                    response = Response({"detail": _("Token is already blacklisted.")},
-                                        status=status.HTTP_404_NOT_FOUND)
-            except AttributeError as e:
-                # warn user blacklist is not enabled if not using JWT_AUTH_COOKIE
-                if not cookie_name:
+            else:
+                # add refresh token to blacklist
+                try:
+                    token = RefreshToken(request.data['refresh'])
+                    token.blacklist()
+                except KeyError:
+                    response = Response({"detail": _("Refresh token was not included.")},
+                                        status=status.HTTP_401_UNAUTHORIZED)
+                except TokenError as e:
+                    if e.args[0] == 'Token is blacklisted':
+                        response = Response({"detail": _("Token is already blacklisted.")},
+                                            status=status.HTTP_404_NOT_FOUND)
+                except AttributeError as e:
+                    # warn user blacklist is not enabled
                     if e.args[0] == "'RefreshToken' object has no attribute 'blacklist'":
                         response = Response({"detail": _("Blacklist is not enabled in INSTALLED_APPS.")},
                                             status=status.HTTP_501_NOT_IMPLEMENTED)

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -134,19 +134,23 @@ class LogoutView(APIView):
             request.user.auth_token.delete()
         except (AttributeError, ObjectDoesNotExist):
             pass
+
         if getattr(settings, 'REST_SESSION_LOGIN', True):
             django_logout(request)
         response = Response({"detail": _("Successfully logged out.")},
                             status=status.HTTP_200_OK)
+
         if getattr(settings, 'REST_USE_JWT', False):
             cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
             if cookie_name:
                 response.delete_cookie(cookie_name)
-            else:
+
+            elif 'rest_framework_simplejwt.token_blacklist' in settings.INSTALLED_APPS:
                 # add refresh token to blacklist
                 try:
                     token = RefreshToken(request.data['refresh'])
                     token.blacklist()
+
                 except KeyError:
                     response = Response({"detail": _("Refresh token was not included in request data.")},
                                         status=status.HTTP_401_UNAUTHORIZED)
@@ -157,10 +161,6 @@ class LogoutView(APIView):
                             response = Response({"detail": _(error.args[0])},
                                                 status=status.HTTP_404_NOT_FOUND)
 
-                        # warn user blacklist is not enabled
-                        elif "'RefreshToken' object has no attribute 'blacklist'" in error.args:
-                            response = Response({"detail": _("Blacklist is not enabled in INSTALLED_APPS.")},
-                                                status=status.HTTP_501_NOT_IMPLEMENTED)
                         else:
                             response = Response({"detail": _("An error has occurred.")},
                                                 status=status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -168,6 +168,12 @@ class LogoutView(APIView):
                     else:
                         response = Response({"detail": _("An error has occurred.")},
                                             status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+            else:
+                response = Response({
+                    "detail": _("Neither cookies or blacklist are enabled, so the token has not been deleted server "
+                                "side. Please make sure the token is deleted client side."
+                                )}, status=status.HTTP_200_OK)
 
         return response
 

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -166,7 +166,7 @@ class LogoutView(APIView):
                                                 status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
                     else:
-                        response = Response({"detail": _("No attr error has occurred.")},
+                        response = Response({"detail": _("An error has occurred.")},
                                             status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         return response

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -137,6 +137,7 @@ class LogoutView(APIView):
 
         if getattr(settings, 'REST_SESSION_LOGIN', True):
             django_logout(request)
+
         response = Response({"detail": _("Successfully logged out.")},
                             status=status.HTTP_200_OK)
 

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -159,7 +159,7 @@ class LogoutView(APIView):
                     if hasattr(error, 'args'):
                         if 'Token is blacklisted' in error.args or 'Token is invalid or expired' in error.args:
                             response = Response({"detail": _(error.args[0])},
-                                                status=status.HTTP_404_NOT_FOUND)
+                                                status=status.HTTP_401_UNAUTHORIZED)
 
                         else:
                             response = Response({"detail": _("An error has occurred.")},


### PR DESCRIPTION
 #27

Attempt to blacklist refresh token if no JWT_AUTH_COOKIE is found and using SimpleJWT Blacklist

Status returned may be questionable in my try/except, but they make sense to me. I'm not sure how the cookies work, so I didn't test that. If there is a better way to implement this (should it be blacklisted even if using cookies?), please let me know!

