### PR TITLE
Don't _require_ rest_framework_simplejwt

### DIFF
--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -12,20 +12,6 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-if getattr(settings, 'REST_USE_JWT'):
-    from rest_framework_simplejwt.exceptions import TokenError
-    from rest_framework_simplejwt.tokens import RefreshToken
-else:
-    # NOTE: these are not actually used except if `REST_USE_JWT` is True, but
-    # ensuring they're defined anyway in case
-
-    class TokenError(Exception):
-        pass
-
-    class RefreshToken:
-        pass
-
-
 from .app_settings import (JWTSerializer, LoginSerializer,
                            PasswordChangeSerializer,
                            PasswordResetConfirmSerializer,
@@ -154,6 +140,13 @@ class LogoutView(APIView):
                             status=status.HTTP_200_OK)
 
         if getattr(settings, 'REST_USE_JWT', False):
+            # NOTE: this import occurs here rather than at the top level
+            # because JWT support is optional, and if `REST_USE_JWT` isn't
+            # True we shouldn't need the dependency
+            from rest_framework_simplejwt.exceptions import TokenError
+            from rest_framework_simplejwt.tokens import RefreshToken
+
+
             cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
             if cookie_name:
                 response.delete_cookie(cookie_name)

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -11,8 +11,20 @@ from rest_framework.generics import GenericAPIView, RetrieveUpdateAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework_simplejwt.exceptions import TokenError
-from rest_framework_simplejwt.tokens import RefreshToken
+
+if getattr(settings, 'REST_USE_JWT'):
+    from rest_framework_simplejwt.exceptions import TokenError
+    from rest_framework_simplejwt.tokens import RefreshToken
+else:
+    # NOTE: these are not actually used except if `REST_USE_JWT` is True, but
+    # ensuring they're defined anyway in case
+
+    class TokenError(Exception):
+        pass
+
+    class RefreshToken:
+        pass
+
 
 from .app_settings import (JWTSerializer, LoginSerializer,
                            PasswordChangeSerializer,


### PR DESCRIPTION
Rather than importing it at the top level (which breaks dj-rest-auth
entirely if you aren't using JWTs and don't have the library installed),
only do the import if the user has the relevant setting enabled.

This appears to have been broken by #28 (in release `1.0.2`)