### PR TITLE
Use import_string for getting TokenModel instead of passing class

### DIFF
--- a/dj_rest_auth/models.py
+++ b/dj_rest_auth/models.py
@@ -1,6 +1,4 @@
 from django.conf import settings
-from rest_framework.authtoken.models import Token as DefaultTokenModel
+from django.utils.module_loading import import_string
 
-# Register your models here.
-
-TokenModel = getattr(settings, 'REST_AUTH_TOKEN_MODEL', DefaultTokenModel)
+TokenModel = import_string(getattr(settings, 'REST_AUTH_TOKEN_MODEL', 'rest_framework.authtoken.models.Token'))

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -40,9 +40,9 @@ Configuration
     
         .. note:: The custom REGISTER_SERIALIZER must define a ``def save(self, request)`` method that returns a user model instance
 
-- **REST_AUTH_TOKEN_MODEL** - model class for tokens, default value ``rest_framework.authtoken.models``
+- **REST_AUTH_TOKEN_MODEL** - path to model class for tokens, default value ``'rest_framework.authtoken.models.Token'``
 
-- **REST_AUTH_TOKEN_CREATOR** - callable to create tokens, default value ``dj_rest_auth.utils.default_create_token``.
+- **REST_AUTH_TOKEN_CREATOR** - path to callable or callable for creating tokens, default value ``dj_rest_auth.utils.default_create_token``.
 
 - **REST_SESSION_LOGIN** - Enable session login in Login API view (default: True)
 


### PR DESCRIPTION
As usual, we prefer set up path to custom classes in settings instead of importing something. 
This PR allows to set up string-like path
`REST_AUTH_TOKEN_MODEL = 'main.models.CustomToken'`
in your settings.py file