### PR TITLE
Pass context to JWTSerializer and TokenSerializer

### DIFF
--- a/dj_rest_auth/registration/views.py
+++ b/dj_rest_auth/registration/views.py
@@ -52,9 +52,9 @@ class RegisterView(CreateAPIView):
                 'access_token': self.access_token,
                 'refresh_token': self.refresh_token
             }
-            return JWTSerializer(data).data
+            return JWTSerializer(data, context=self.get_serializer_context()).data
         else:
-            return TokenSerializer(user.auth_token).data
+            return TokenSerializer(user.auth_token, context=self.get_serializer_context()).data
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)


### PR DESCRIPTION
Useful for overridden Token/JWT serailizers which need to utilize request context.

Resolves https://github.com/jazzband/dj-rest-auth/issues/51