### PR TITLE
serializers: import gettext_lazy

### DIFF
--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -5,7 +5,10 @@ from django.contrib.auth.tokens import default_token_generator
 from django.utils.encoding import force_text
 from django.utils.http import urlsafe_base64_decode as uid_decoder
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import gettext_lazy as _
+except ImportError:
+    from django.utils.translation import ugettext_lazy as _
 from rest_framework import exceptions, serializers
 from rest_framework.exceptions import ValidationError
 


### PR DESCRIPTION
Per Django's warning, ugettext_lazy will be removed in a future version.