### PR TITLE
Add a note in registration to use allauth urls if account email verification is mandatory

### DIFF
--- a/docs/api_endpoints.rst
+++ b/docs/api_endpoints.rst
@@ -61,6 +61,11 @@ Registration
 
     - key
 
+    .. note:: If you set account email verification as mandatory, you have to add the VerifyEmailView with the used `name`.
+        You need to import the view: ``from rest_auth.registration.views import VerifyEmailView``. Then add the url with the corresponding name:
+        ``url(r'^rest-auth/account-confirm-email/', VerifyEmailView.as_view(), name='account_email_verification_sent')`` to the urlpatterns list.
+    
+
 
 Social Media Authentication
 ---------------------------


### PR DESCRIPTION
To solve this issue in django-rest-auth: https://github.com/Tivix/django-rest-auth/issues/576