### PR TITLE
Make verify email browsable

### DIFF
--- a/dj_rest_auth/registration/views.py
+++ b/dj_rest_auth/registration/views.py
@@ -19,7 +19,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.debug import sensitive_post_parameters
 from rest_framework import status
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, MethodNotAllowed
 from rest_framework.generics import CreateAPIView, GenericAPIView, ListAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -85,6 +85,9 @@ class VerifyEmailView(APIView, ConfirmEmailView):
 
     def get_serializer(self, *args, **kwargs):
         return VerifyEmailSerializer(*args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        raise MethodNotAllowed('GET')
 
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)

--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -466,6 +466,13 @@ class APIBasicTests(TestsMixin, TestCase):
         new_user = get_user_model().objects.latest('id')
         self.assertEqual(new_user.username, self.REGISTRATION_DATA['username'])
 
+        # test browsable endpoint
+        result = self.get(
+            self.verify_email_url
+        )
+        self.assertEqual(result.status_code, 405)
+        self.assertEqual(result.json['detail'], 'Method "GET" not allowed.')
+
         # email is not verified yet
         payload = {
             "username": self.USERNAME,


### PR DESCRIPTION
Verify email was not browsable. get function added in order to solve that.
Fix issue: https://github.com/Tivix/django-rest-auth/issues/558