### PR TITLE
Override TokenRefreshView to update JWT_AUTH_COOKIE cookie

### DIFF
--- a/dj_rest_auth/tests/urls.py
+++ b/dj_rest_auth/tests/urls.py
@@ -90,3 +90,11 @@ urlpatterns += [
     url(r'^accounts/', include('allauth.socialaccount.urls')),
     url(r'^getcsrf/', get_csrf_cookie, name='getcsrf'),
 ]
+
+from rest_framework_simplejwt.views import (TokenVerifyView,)
+from dj_rest_auth.views import (TokenRefreshView)
+
+urlpatterns += [
+    url(r'^token/verify/$', TokenVerifyView.as_view(), name='token_verify'),
+    url(r'^token/refresh/$', TokenRefreshView.as_view(), name='token_refresh'),
+]

--- a/dj_rest_auth/urls.py
+++ b/dj_rest_auth/urls.py
@@ -19,9 +19,8 @@ urlpatterns = [
 ]
 
 if getattr(settings, 'REST_USE_JWT', False):
-    from rest_framework_simplejwt.views import (
-        TokenRefreshView, TokenVerifyView,
-    )
+    from rest_framework_simplejwt.views import (TokenVerifyView,)
+    from dj_rest_auth.views import (TokenRefreshView)
 
     urlpatterns += [
         url(r'^token/verify/$', TokenVerifyView.as_view(), name='token_verify'),

--- a/docs/api_endpoints.rst
+++ b/docs/api_endpoints.rst
@@ -64,8 +64,25 @@ Registration
     .. note:: If you set account email verification as mandatory, you have to add the VerifyEmailView with the used `name`.
         You need to import the view: ``from dj_rest_auth.registration.views import VerifyEmailView``. Then add the url with the corresponding name:
         ``path('dj-rest-auth/account-confirm-email/', VerifyEmailView.as_view(), name='account_email_verification_sent')`` to the urlpatterns list.
-        
 
+JSON Web Token
+--------------
+
+.. note:: These endpoints are only available if REST_USE_JWT is set to True
+
+- /dj-rest-auth/token/verify/ (POST)
+
+    - token
+
+    Verifies token validity
+
+- /dj-rest-auth/token/refresh/ (POST)
+
+    - refresh
+
+    Given a valid refresh token, returns a new access token
+
+    .. note:: If JWT_AUTH_COOKIE is set, the access token will be stored in the cookie.
 
 Social Media Authentication
 ---------------------------


### PR DESCRIPTION
Add a dedicated view that subclasses django-rest-framework-simplejwt's
TokenRefreshView to update the JWT_AUTH_COOKIE on successful refreshes.

Fixes: #97