### PR TITLE
Allow using without jwt dependency

### DIFF
--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -123,7 +123,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
-        'dj_rest_auth.utils.JWTCookieAuthentication'
+        'dj_rest_auth.jwt_auth.JWTCookieAuthentication'
     ),
     'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema'
 }

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ responses>=0.5.0
 djangorestframework-simplejwt==4.4.0
 django-allauth>=0.25.0
 coveralls>=1.11.1
+unittest-xml-reporting>=3.0.2

--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+
+class JWTCookieAuthentication(JWTAuthentication):
+    """
+    An authentication plugin that hopefully authenticates requests through a JSON web
+    token provided in a request cookie (and through the header as normal, with a
+    preference to the header).
+    """
+
+    def authenticate(self, request):
+        cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
+        header = self.get_header(request)
+        if header is None:
+            if cookie_name:
+                raw_token = request.COOKIES.get(cookie_name)
+            else:
+                return None
+        else:
+            raw_token = self.get_raw_token(header)
+
+        if raw_token is None:
+            return None
+
+        validated_token = self.get_validated_token(raw_token)
+        return self.get_user(validated_token), validated_token

--- a/dj_rest_auth/tests/settings.py
+++ b/dj_rest_auth/tests/settings.py
@@ -68,7 +68,7 @@ TEMPLATES = [
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
-        'dj_rest_auth.utils.JWTCookieAuthentication',
+        'dj_rest_auth.jwt_auth.JWTCookieAuthentication',
     )
 }
 

--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -563,7 +563,7 @@ class APIBasicTests(TestsMixin, TestCase):
     @override_settings(JWT_AUTH_COOKIE='jwt-auth')
     @override_settings(REST_FRAMEWORK=dict(
         DEFAULT_AUTHENTICATION_CLASSES=[
-            'dj_rest_auth.utils.JWTCookieAuthentication'
+            'dj_rest_auth.jwt_auth.JWTCookieAuthentication'
         ]
     ))
     @override_settings(REST_SESSION_LOGIN=False)
@@ -624,7 +624,7 @@ class APIBasicTests(TestsMixin, TestCase):
     @override_settings(JWT_AUTH_COOKIE=None)
     @override_settings(REST_FRAMEWORK=dict(
         DEFAULT_AUTHENTICATION_CLASSES=[
-            'dj_rest_auth.utils.JWTCookieAuthentication'
+            'dj_rest_auth.jwt_auth.JWTCookieAuthentication'
         ]
     ))
     @override_settings(REST_SESSION_LOGIN=False)
@@ -649,7 +649,7 @@ class APIBasicTests(TestsMixin, TestCase):
     @override_settings(JWT_AUTH_COOKIE='jwt-auth')
     @override_settings(REST_FRAMEWORK=dict(
         DEFAULT_AUTHENTICATION_CLASSES=[
-            'dj_rest_auth.utils.JWTCookieAuthentication'
+            'dj_rest_auth.jwt_auth.JWTCookieAuthentication'
         ]
     ))
     @override_settings(REST_SESSION_LOGIN=False)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,9 +35,9 @@ Installation
 
 .. code-block:: python
 
-    python manage.py migrate 
-    
-    
+    python manage.py migrate
+
+
 You're good to go now!
 
 
@@ -59,7 +59,7 @@ Registration (optional)
         'allauth.account',
         'dj_rest_auth.registration',
     )
-    
+
     SITE_ID = 1
 
 3. Add dj_rest_auth.registration urls:
@@ -76,7 +76,7 @@ Registration (optional)
 Social Authentication (optional)
 --------------------------------
 
-Using ``django-allauth``, ``dj-rest-auth`` provides helpful class for creating social media authentication view. 
+Using ``django-allauth``, ``dj-rest-auth`` provides helpful class for creating social media authentication view.
 
 .. note:: Points 1 and 2 are related to ``django-allauth`` configuration, so if you have already configured social authentication, then please go to step 3. See ``django-allauth`` documentation for more details.
 
@@ -223,7 +223,7 @@ In urls.py:
 You can also use the following views to check all social accounts attached to the current authenticated user and disconnect selected social accounts:
 
 .. code-block:: python
-    
+
     from dj_rest_auth.registration.views import (
         SocialAccountListView, SocialAccountDisconnectView
     )
@@ -259,7 +259,7 @@ By default ``dj-rest-auth`` uses Django's Token-based authentication. If you wan
         ...
         'DEFAULT_AUTHENTICATION_CLASSES': (
             ...
-            'dj_rest_auth.utils.JWTCookieAuthentication',
+            'dj_rest_auth.jwt_auth.JWTCookieAuthentication',
         )
         ...
     }


### PR DESCRIPTION
The changes in #99 made the package impossible to use without installing simplejwt. This PR moves the JWT authentication class to a separate module so it can be imported directly and not from utils, which allows to import simplejwt without try/except, so an error will still be raised when explicitly importing from the new module. It also restores the old behavior when importing from utils. Importing from utils can be deprecated in the future.