### PR TITLE
Fixes JWT_TOKEN_CLAIMS_SERIALIZER get attribute

### DIFF
--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -628,7 +628,11 @@ class APIBasicTests(TestsMixin, TestCase):
         ]
     ))
     @override_settings(REST_SESSION_LOGIN=False)
-    @override_settings(JWT_TOKEN_CLAIMS_SERIALIZER = 'tests.test_api.TESTTokenObtainPairSerializer')
+    @override_settings(
+        REST_AUTH_SERIALIZERS={
+            "JWT_TOKEN_CLAIMS_SERIALIZER": 'tests.test_api.TESTTokenObtainPairSerializer'
+        }
+    )
     def test_custom_jwt_claims(self):
         payload = {
             "username": self.USERNAME,
@@ -653,7 +657,11 @@ class APIBasicTests(TestsMixin, TestCase):
         ]
     ))
     @override_settings(REST_SESSION_LOGIN=False)
-    @override_settings(JWT_TOKEN_CLAIMS_SERIALIZER = 'tests.test_api.TESTTokenObtainPairSerializer')
+    @override_settings(
+        REST_AUTH_SERIALIZERS={
+            "JWT_TOKEN_CLAIMS_SERIALIZER": 'tests.test_api.TESTTokenObtainPairSerializer'
+        }
+    )
     def test_custom_jwt_claims_cookie_w_authentication(self):
         payload = {
             "username": self.USERNAME,

--- a/dj_rest_auth/utils.py
+++ b/dj_rest_auth/utils.py
@@ -19,7 +19,14 @@ def default_create_token(token_model, user, serializer):
 
 def jwt_encode(user):
     from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
-    TOPS = import_callable(getattr(settings, 'JWT_TOKEN_CLAIMS_SERIALIZER', TokenObtainPairSerializer))
+    rest_auth_serializers = getattr(settings, 'REST_AUTH_SERIALIZERS', {})
+
+    JWTTokenClaimsSerializer = rest_auth_serializers.get(
+        'JWT_TOKEN_CLAIMS_SERIALIZER',
+        TokenObtainPairSerializer
+    )
+
+    TOPS = import_callable(JWTTokenClaimsSerializer)
     refresh = TOPS.get_token(user)
     return refresh.access_token, refresh
 


### PR DESCRIPTION
Fixes JWT_TOKEN_CLAIMS_SERIALIZER not being able to be overwritten from the REST_AUTH_SERIALIZERS dict in settings.py.