### PR TITLE
fix tests override settings for TokenObtainPairSerializer

### DIFF
--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -628,7 +628,11 @@ class APIBasicTests(TestsMixin, TestCase):
         ]
     ))
     @override_settings(REST_SESSION_LOGIN=False)
-    @override_settings(JWT_TOKEN_CLAIMS_SERIALIZER = 'tests.test_api.TESTTokenObtainPairSerializer')
+    @override_settings(
+        REST_AUTH_SERIALIZERS={
+            "JWT_TOKEN_CLAIMS_SERIALIZER": TESTTokenObtainPairSerializer
+        }
+    )
     def test_custom_jwt_claims(self):
         payload = {
             "username": self.USERNAME,
@@ -653,7 +657,11 @@ class APIBasicTests(TestsMixin, TestCase):
         ]
     ))
     @override_settings(REST_SESSION_LOGIN=False)
-    @override_settings(JWT_TOKEN_CLAIMS_SERIALIZER = 'tests.test_api.TESTTokenObtainPairSerializer')
+    @override_settings(
+        REST_AUTH_SERIALIZERS={
+            "JWT_TOKEN_CLAIMS_SERIALIZER": TESTTokenObtainPairSerializer
+        }
+    )
     def test_custom_jwt_claims_cookie_w_authentication(self):
         payload = {
             "username": self.USERNAME,

--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -630,7 +630,7 @@ class APIBasicTests(TestsMixin, TestCase):
     @override_settings(REST_SESSION_LOGIN=False)
     @override_settings(
         REST_AUTH_SERIALIZERS={
-            "JWT_TOKEN_CLAIMS_SERIALIZER": TESTTokenObtainPairSerializer
+            "JWT_TOKEN_CLAIMS_SERIALIZER": 'tests.test_api.TESTTokenObtainPairSerializer'
         }
     )
     def test_custom_jwt_claims(self):
@@ -659,7 +659,7 @@ class APIBasicTests(TestsMixin, TestCase):
     @override_settings(REST_SESSION_LOGIN=False)
     @override_settings(
         REST_AUTH_SERIALIZERS={
-            "JWT_TOKEN_CLAIMS_SERIALIZER": TESTTokenObtainPairSerializer
+            "JWT_TOKEN_CLAIMS_SERIALIZER": 'tests.test_api.TESTTokenObtainPairSerializer'
         }
     )
     def test_custom_jwt_claims_cookie_w_authentication(self):


### PR DESCRIPTION
The tests are getting the override serializers from a variable, but the documentation says to create a dictionary in the settings file.

Refer also to this: https://github.com/jazzband/dj-rest-auth/pull/107