### PR TITLE
Update install docs to prevent unhandled error on user deletion

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,7 +46,7 @@ Registration (optional)
 
 1. If you want to enable standard registration process you will need to install ``django-allauth`` by using ``pip install 'dj-rest-auth[with_social]'``.
 
-2. Add ``django.contrib.sites``, ``allauth``, ``allauth.account``, ``authauth.socialaccount`` and ``dj_rest_auth.registration`` apps to INSTALLED_APPS in your django settings.py:
+2. Add ``django.contrib.sites``, ``allauth``, ``allauth.account``, ``allauth.socialaccount`` and ``dj_rest_auth.registration`` apps to INSTALLED_APPS in your django settings.py:
 
 3. Add ``SITE_ID = 1``  to your django settings.py
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,7 +46,7 @@ Registration (optional)
 
 1. If you want to enable standard registration process you will need to install ``django-allauth`` by using ``pip install 'dj-rest-auth[with_social]'``.
 
-2. Add ``django.contrib.sites``, ``allauth``, ``allauth.account`` and ``dj_rest_auth.registration`` apps to INSTALLED_APPS in your django settings.py:
+2. Add ``django.contrib.sites``, ``allauth``, ``allauth.account``, ``authauth.socialaccount`` and ``dj_rest_auth.registration`` apps to INSTALLED_APPS in your django settings.py:
 
 3. Add ``SITE_ID = 1``  to your django settings.py
 
@@ -57,6 +57,7 @@ Registration (optional)
         'django.contrib.sites',
         'allauth',
         'allauth.account',
+        'allauth.socialaccount',
         'dj_rest_auth.registration',
     )
 


### PR DESCRIPTION
If using `django-allauth`, the `allauth.socialaccount` app is *required*, or else errors will occur when deleting users (and possibly in other places).
The `allauth.socialaccount` app cannot be left out even if you're just doing email registration and not using the social auth providers.
See: https://github.com/pennersr/django-allauth/issues/1975#issuecomment-384075169

Another user of this library also got tripped up here: https://github.com/jazzband/dj-rest-auth/issues/18#issue-590399626