### PR TITLE
added authentication_classes to PasswordChangeView

### DIFF
--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -9,6 +9,7 @@ from django.views.decorators.debug import sensitive_post_parameters
 from rest_framework import status
 from rest_framework.generics import GenericAPIView, RetrieveUpdateAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.authentication import TokenAuthentication
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -273,6 +274,7 @@ class PasswordChangeView(GenericAPIView):
     """
     serializer_class = PasswordChangeSerializer
     permission_classes = (IsAuthenticated,)
+    authentication_classes = (TokenAuthentication,)
     throttle_scope = 'dj_rest_auth'
 
     @sensitive_post_parameters_m


### PR DESCRIPTION
Making a POST request to **http://127.0.0.1:8000/auth/password/change/** route to change the password, throws this error. *Authentication credentials were not provided*. Because **authentication_classes** were missing from **PasswordChangeView**.

![Screenshot from 2020-07-10 17-56-17](https://user-images.githubusercontent.com/41537758/87243553-8a9c0880-c454-11ea-82fa-4369f6c0661e.png)

I just added **authentication_classes** (ie. **TokenAuthentication**)