### PR TITLE
Use path() and re_path() instead of the deprecated url()

### DIFF
--- a/dj_rest_auth/registration/urls.py
+++ b/dj_rest_auth/registration/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 from django.views.generic import TemplateView
 
 from .views import RegisterView, VerifyEmailView
 
 urlpatterns = [
-    url(r'^$', RegisterView.as_view(), name='rest_register'),
-    url(r'^verify-email/$', VerifyEmailView.as_view(), name='rest_verify_email'),
+    path('', RegisterView.as_view(), name='rest_register'),
+    path('verify-email/', VerifyEmailView.as_view(), name='rest_verify_email'),
 
     # This url is used by django-allauth and empty TemplateView is
     # defined just to allow reverse() call inside app, for example when email
@@ -18,6 +18,6 @@ urlpatterns = [
     # If you don't want to use API on that step, then just use ConfirmEmailView
     # view from:
     # django-allauth https://github.com/pennersr/django-allauth/blob/master/allauth/account/views.py
-    url(r'^account-confirm-email/(?P<key>[-:\w]+)/$', TemplateView.as_view(),
+    re_path(r'^account-confirm-email/(?P<key>[-:\w]+)/$', TemplateView.as_view(),
         name='account_confirm_email'),
 ]

--- a/dj_rest_auth/urls.py
+++ b/dj_rest_auth/urls.py
@@ -1,21 +1,21 @@
 from dj_rest_auth.views import (LoginView, LogoutView, PasswordChangeView,
                                 PasswordResetConfirmView, PasswordResetView,
                                 UserDetailsView)
-from django.conf.urls import url
+from django.urls import path
 from django.conf import settings
 
 urlpatterns = [
     # URLs that do not require a session or valid token
-    url(r'^password/reset/$', PasswordResetView.as_view(),
-        name='rest_password_reset'),
-    url(r'^password/reset/confirm/$', PasswordResetConfirmView.as_view(),
-        name='rest_password_reset_confirm'),
-    url(r'^login/$', LoginView.as_view(), name='rest_login'),
+    path('password/reset/', PasswordResetView.as_view(),
+         name='rest_password_reset'),
+    path('password/reset/confirm/', PasswordResetConfirmView.as_view(),
+         name='rest_password_reset_confirm'),
+    path('login/', LoginView.as_view(), name='rest_login'),
     # URLs that require a user to be logged in with a valid session / token.
-    url(r'^logout/$', LogoutView.as_view(), name='rest_logout'),
-    url(r'^user/$', UserDetailsView.as_view(), name='rest_user_details'),
-    url(r'^password/change/$', PasswordChangeView.as_view(),
-        name='rest_password_change'),
+    path('logout/', LogoutView.as_view(), name='rest_logout'),
+    path('user/', UserDetailsView.as_view(), name='rest_user_details'),
+    path('password/change/', PasswordChangeView.as_view(),
+         name='rest_password_change'),
 ]
 
 if getattr(settings, 'REST_USE_JWT', False):
@@ -24,6 +24,6 @@ if getattr(settings, 'REST_USE_JWT', False):
     )
 
     urlpatterns += [
-        url(r'^token/verify/$', TokenVerifyView.as_view(), name='token_verify'),
-        url(r'^token/refresh/$', TokenRefreshView.as_view(), name='token_refresh'),
+        path('token/verify/', TokenVerifyView.as_view(), name='token_verify'),
+        path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     ]

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
     keywords='django rest auth registration rest-framework django-registration api',
     zip_safe=False,
     install_requires=[
-        'Django>=1.11',
-        'djangorestframework>=3.1.3',
+        'Django>=2.0',
+        'djangorestframework>=3.7.0',
     ],
     extras_require={
         'with_social': ['django-allauth>=0.25.0'],


### PR DESCRIPTION
Ran 43 tests in 16.669s

OK


All tests run successfully for all changes with the new versions 