### PR TITLE
Fixes tests not running explicitly declared versions + maintenance. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,14 @@ jobs:
     docker:
       - image: circleci/python:3.8.0
     environment:
-      DJANGO_VERSION: 3.0.3
-      DRF: 3.11
+      DJANGO_VERSION: 3.1
+      DRF: 3.11.1
     executor: docker/docker
     steps:
       - checkout
       - run:
-          command: pip install --user -r dev-requirements.txt
-          name: "Pip Install dev requirements"
+          command: pip install --user Django==$DJANGO_VERSION djangorestframework==$DRF
+          name: "Pip install version-specific Django + DRF"
       - run:
           command: pip install --user -r dj_rest_auth/tests/requirements.pip
           name: "Pip Install test requirements"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,0 @@
---editable .
-responses>=0.5.0
-djangorestframework-simplejwt==4.4.0
-django-allauth>=0.25.0
-coveralls>=1.11.1
-unittest-xml-reporting>=3.0.2

--- a/dj_rest_auth/tests/requirements.pip
+++ b/dj_rest_auth/tests/requirements.pip
@@ -2,3 +2,5 @@ django-allauth>=0.25.0
 responses>=0.5.0
 flake8==2.4.0
 djangorestframework-simplejwt==4.4.0
+unittest-xml-reporting>=3.0.2
+coveralls>=1.11.1

--- a/dj_rest_auth/urls.py
+++ b/dj_rest_auth/urls.py
@@ -6,16 +6,13 @@ from django.conf import settings
 
 urlpatterns = [
     # URLs that do not require a session or valid token
-    path('password/reset/', PasswordResetView.as_view(),
-         name='rest_password_reset'),
-    path('password/reset/confirm/', PasswordResetConfirmView.as_view(),
-         name='rest_password_reset_confirm'),
+    path('password/reset/', PasswordResetView.as_view(), name='rest_password_reset'),
+    path('password/reset/confirm/', PasswordResetConfirmView.as_view(), name='rest_password_reset_confirm'),
     path('login/', LoginView.as_view(), name='rest_login'),
     # URLs that require a user to be logged in with a valid session / token.
     path('logout/', LogoutView.as_view(), name='rest_logout'),
     path('user/', UserDetailsView.as_view(), name='rest_user_details'),
-    path('password/change/', PasswordChangeView.as_view(),
-         name='rest_password_change'),
+    path('password/change/', PasswordChangeView.as_view(), name='rest_password_change'),
 ]
 
 if getattr(settings, 'REST_USE_JWT', False):


### PR DESCRIPTION
- The CI Config should run across multiple combinations of Django + DRF starting from Django 2.  We do this in a DRY way by utilizing anchors in the Circle CI config, but for some reason the explicit versions of Django weren't running. This PR fixes that.
- Consolidates dj_rest_auth/tests/requirements.pip  and dev-requirements.txt into one.
- White space improvements on URLS.