### PR TITLE
Fix no context in serializer issue

### DIFF
--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -105,7 +105,7 @@ class LoginView(GenericAPIView):
 
     def post(self, request, *args, **kwargs):
         self.request = request
-        self.serializer = self.get_serializer(data=self.request.data)
+        self.serializer = self.get_serializer(data=self.request.data, context=self.get_serializer_context())
         self.serializer.is_valid(raise_exception=True)
 
         self.login()


### PR DESCRIPTION
Fix bugs for views couldn't be found in SocialLoginSerializer. The SocialLoginSerializer need context. 