### PR TITLE
Add support for Refresh Token Cookie

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,45 +3,44 @@ orbs:
   docker: circleci/docker@0.6.0
 
 jobs:
-  test-django-3: &template
+  test:
     docker:
       - image: circleci/python:3.8.0
-    environment:
-      DJANGO_VERSION: 3.1
-      DRF: 3.11.1
     executor: docker/docker
     steps:
       - checkout
       - run:
-          command: pip install --user Django==$DJANGO_VERSION djangorestframework==$DRF
-          name: "Pip install version-specific Django + DRF"
+          command: pip install --user tox coverage coveralls
+          name: "Install Tox & Coverage"
       - run:
-          command: pip install --user -r dj_rest_auth/tests/requirements.pip
-          name: "Pip Install test requirements"
+          command: tox
+          name: "Run Tox on All Supported Django and Python Versions"
       - run:
           command: |
             mkdir -p test-results/
-            coverage run --source=dj_rest_auth setup.py test
-            coverage report
-          name: Test
+            tox -e coverage
+          name: "Generate Coverage Report"
       - run:
           command: COVERALLS_REPO_TOKEN=Q58WdUuZOi89XHyDeDsGE2lxUGQ2IfqP3 coveralls
-          name: Coverage
+          name: "Send results to Coveralls"
+      - store_test_results:
+          path: test-results/
+  build:
+    docker:
+      - image: circleci/python:3.8.0
+    executor: docker/docker
+    steps:
+      - checkout
       - run:
           command: python3 setup.py sdist
           name: Build
-      - store_test_results:
-          path: test-results/
       - store_artifacts:
           path: dist/
-  test-django-2:
-    <<: *template
-    environment:
-      DJANGO_VERSION: 2.2.10
-      DRF: 3.9
 
 workflows:
   main:
     jobs:
-      - test-django-3
-      - test-django-2
+      - test
+      - build:
+          requires:
+            - test

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+coverage_html/
 .tox/
 .coverage
 .coverage.*

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Drop-in API endpoints for handling authentication securely in Django Rest Framew
 with SPAs (e.g React, Vue, Angular), and Mobile applications. 
 
 ## Requirements
-- Django 2 or 3.
+- Django 2 or 3 (<3.1)
 - Python 3
 
 ## Quick Setup

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Drop-in API endpoints for handling authentication securely in Django Rest Framew
 with SPAs (e.g React, Vue, Angular), and Mobile applications. 
 
 ## Requirements
-- Django 2 or 3 (<3.1)
+- Django 2 or 3
 - Python 3
 
 ## Quick Setup

--- a/dj_rest_auth/__version__.py
+++ b/dj_rest_auth/__version__.py
@@ -1,7 +1,7 @@
 __title__ = 'dj-rest-auth'
 __description__ = 'Authentication and Registration in Django Rest Framework.'
 __url__ = 'http://github.com/jazzband/dj-rest-auth'
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 __author__ = '@iMerica https://github.com/iMerica'
 __author_email__ = 'imichael@pm.me'
 __license__ = 'MIT'

--- a/dj_rest_auth/__version__.py
+++ b/dj_rest_auth/__version__.py
@@ -1,7 +1,7 @@
 __title__ = 'dj-rest-auth'
 __description__ = 'Authentication and Registration in Django Rest Framework.'
 __url__ = 'http://github.com/jazzband/dj-rest-auth'
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 __author__ = '@iMerica https://github.com/iMerica'
 __author_email__ = 'imichael@pm.me'
 __license__ = 'MIT'

--- a/dj_rest_auth/__version__.py
+++ b/dj_rest_auth/__version__.py
@@ -1,7 +1,7 @@
 __title__ = 'dj-rest-auth'
 __description__ = 'Authentication and Registration in Django Rest Framework.'
 __url__ = 'http://github.com/jazzband/dj-rest-auth'
-__version__ = '1.1.2'
+__version__ = '2.0.0'
 __author__ = '@iMerica https://github.com/iMerica'
 __author_email__ = 'imichael@pm.me'
 __license__ = 'MIT'

--- a/dj_rest_auth/app_settings.py
+++ b/dj_rest_auth/app_settings.py
@@ -22,7 +22,7 @@ TokenSerializer = import_callable(serializers.get('TOKEN_SERIALIZER', DefaultTok
 
 JWTSerializer = import_callable(serializers.get('JWT_SERIALIZER', DefaultJWTSerializer))
 
-DefaultJWTSerializerWithExpiration = import_callable(serializers.get('JWT_SERIALIZER_WITH_EXPIRATION', DefaultJWTSerializerWithExpiration))
+JWTSerializerWithExpiration = import_callable(serializers.get('JWT_SERIALIZER_WITH_EXPIRATION', DefaultJWTSerializerWithExpiration))
 
 UserDetailsSerializer = import_callable(serializers.get('USER_DETAILS_SERIALIZER', DefaultUserDetailsSerializer))
 

--- a/dj_rest_auth/app_settings.py
+++ b/dj_rest_auth/app_settings.py
@@ -1,4 +1,5 @@
 from dj_rest_auth.serializers import JWTSerializer as DefaultJWTSerializer
+from dj_rest_auth.serializers import JWTSerializerWithExpiration as DefaultJWTSerializerWithExpiration
 from dj_rest_auth.serializers import LoginSerializer as DefaultLoginSerializer
 from dj_rest_auth.serializers import \
     PasswordChangeSerializer as DefaultPasswordChangeSerializer
@@ -20,6 +21,8 @@ serializers = getattr(settings, 'REST_AUTH_SERIALIZERS', {})
 TokenSerializer = import_callable(serializers.get('TOKEN_SERIALIZER', DefaultTokenSerializer))
 
 JWTSerializer = import_callable(serializers.get('JWT_SERIALIZER', DefaultJWTSerializer))
+
+DefaultJWTSerializerWithExpiration = import_callable(serializers.get('JWT_SERIALIZER_WITH_EXPIRATION', DefaultJWTSerializerWithExpiration))
 
 UserDetailsSerializer = import_callable(serializers.get('USER_DETAILS_SERIALIZER', DefaultUserDetailsSerializer))
 

--- a/dj_rest_auth/app_settings.py
+++ b/dj_rest_auth/app_settings.py
@@ -38,3 +38,4 @@ PasswordChangeSerializer = import_callable(
 )
 
 JWT_AUTH_COOKIE = getattr(settings, 'JWT_AUTH_COOKIE', None)
+JWT_AUTH_REFRESH_COOKIE = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE', None)

--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -131,7 +131,7 @@ class UserDetailsSerializer(serializers.ModelSerializer):
     """
     class Meta:
         model = UserModel
-        fields = ('pk', 'username', 'email', 'first_name', 'last_name')
+        fields = ('pk', UserModel.USERNAME_FIELD, UserModel.EMAIL_FIELD, 'first_name', 'last_name')
         read_only_fields = ('email', )
 
 

--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -161,6 +161,11 @@ class JWTSerializer(serializers.Serializer):
         return user_data
 
 
+class JWTSerializerWithExpiration(JWTSerializer):
+    access_token_expiration = serializers.DateTimeField()
+    refresh_token_expiration = serializers.DateTimeField()
+
+
 class PasswordResetSerializer(serializers.Serializer):
     """
     Serializer for requesting a password reset e-mail.

--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -162,6 +162,9 @@ class JWTSerializer(serializers.Serializer):
 
 
 class JWTSerializerWithExpiration(JWTSerializer):
+    """
+    Serializer for JWT authentication with expiration times.
+    """
     access_token_expiration = serializers.DateTimeField()
     refresh_token_expiration = serializers.DateTimeField()
 

--- a/dj_rest_auth/tests/requirements.pip
+++ b/dj_rest_auth/tests/requirements.pip
@@ -1,6 +1,6 @@
-django-allauth>=0.25.0
-responses>=0.5.0
+django-allauth==0.42.0
+responses==0.10.0
 flake8==2.4.0
 djangorestframework-simplejwt==4.4.0
-unittest-xml-reporting>=3.0.2
-coveralls>=1.11.1
+unittest-xml-reporting==3.0.2
+coveralls==1.11.1

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -104,6 +104,7 @@ class LoginView(GenericAPIView):
         if getattr(settings, 'REST_USE_JWT', False):
             cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
             refresh_cookie_name = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE', None)
+            refresh_cookie_path = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE_PATH', '/')
             cookie_secure = getattr(settings, 'JWT_AUTH_SECURE', False)
             cookie_httponly = getattr(settings, 'JWT_AUTH_HTTPONLY', True)
             cookie_samesite = getattr(settings, 'JWT_AUTH_SAMESITE', 'Lax')
@@ -125,7 +126,8 @@ class LoginView(GenericAPIView):
                     expires=refresh_token_expiration,
                     secure=cookie_secure,
                     httponly=cookie_httponly,
-                    samesite=cookie_samesite
+                    samesite=cookie_samesite,
+                    path=refresh_cookie_path
                 )
         return response
 

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -12,6 +12,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from serializers import JWTSerializerWithExpiration
 from .app_settings import (JWTSerializer, LoginSerializer,
                            PasswordChangeSerializer,
                            PasswordResetConfirmSerializer,
@@ -51,7 +52,12 @@ class LoginView(GenericAPIView):
 
     def get_response_serializer(self):
         if getattr(settings, 'REST_USE_JWT', False):
-            response_serializer = JWTSerializer
+
+            if getattr(settings, 'JWT_AUTH_RETURN_EXPIRATION', False):
+                response_serializer = JWTSerializerWithExpiration
+            else:
+                response_serializer = JWTSerializer
+
         else:
             response_serializer = TokenSerializer
         return response_serializer

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -12,8 +12,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from serializers import JWTSerializerWithExpiration
-from .app_settings import (JWTSerializer, LoginSerializer,
+from .app_settings import (JWTSerializer, JWTSerializerWithExpiration, LoginSerializer,
                            PasswordChangeSerializer,
                            PasswordResetConfirmSerializer,
                            PasswordResetSerializer, TokenSerializer,

--- a/setup.py
+++ b/setup.py
@@ -27,16 +27,16 @@ setup(
     keywords='django rest auth registration rest-framework django-registration api',
     zip_safe=False,
     install_requires=[
-        'Django>=2.0',
+        'Django>=2.0,<3.1',
         'djangorestframework>=3.7.0',
     ],
     extras_require={
-        'with_social': ['django-allauth>=0.25.0'],
+        'with_social': ['django-allauth>=0.40.0,<0.43.0'],
     },
     tests_require=[
         'unittest-xml-reporting>=3.0.2',
         'responses>=0.5.0',
-        'django-allauth>=0.25.0',
+        'django-allauth==0.40.0',
         'djangorestframework-simplejwt>=4.4.0 ',
         'coveralls>=1.11.1'
     ],

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     keywords='django rest auth registration rest-framework django-registration api',
     zip_safe=False,
     install_requires=[
-        'Django>=2.0,<3.1',
+        'Django>=2.0',
         'djangorestframework>=3.7.0',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
 deps =
     -rdj_rest_auth/tests/requirements.pip
     django2: Django>=2.2,<2.3
-    django3: Django>=3.0,<3.1
+    django3: Django>=3.1.3
 
 # Configuration for coverage and flake8 is being set in `./setup.cfg`
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -10,16 +10,16 @@
 [tox]
 skipsdist = true
 envlist =
-    python{3.5,3.6,3.7,3.8}-django22
-    python{3.6,3.7,3.8}-django31
+    python{3.5,3.6,3.7,3.8,3.9}-django2
+    python{3.6,3.7,3.8,3.9}-django3
 
 [testenv]
 commands =
     python ./runtests.py
 deps =
     -rdj_rest_auth/tests/requirements.pip
-    django22: Django>=2.2,<2.3
-    django31: Django>=3.1
+    django2: Django>=2.2,<2.3
+    django3: Django>=3.0,<3.1
 
 # Configuration for coverage and flake8 is being set in `./setup.cfg`
 [testenv:coverage]


### PR DESCRIPTION
Whilst using dj-rest-auth I was struggling to securely store users refresh tokens. I am developing my app in JS so only have Cookies, Local Storage & Session Storage available. Out of the three the only place, I would want to store my tokens would be in HttpOnly Cookies. Out of the box dj-rest-auth supports Token Cookies so I just followed the same pattern used and added Refresh Token Cookies.

There are two new settings for the Refresh Token:

JWT_AUTH_REFRESH_COOKIE
This is the name of the cookie that will store the refresh token

JWT_AUTH_REFRESH_COOKIE_PATH
This is the path set within the cookie, this stops the cookie from being sent with every request.
e.g. only /dj-rest-auth/token/refresh


In addition to the Refresh Cookie, the PR also includes a feature that allows users to return the token and refresh token expiry times. This is helpful as it allows the client to know when tokens are set to expire without disabling HttpOnly on the Cookies.

Setting:
JWT_AUTH_RETURN_EXPIRATION

This is my first PR so please let me know how I can improve any future requests.

If you would like an example of the middleware used so SimpleJWT can access the Token and RefreshToken on calls like /token/verify/ & /token/refresh/ I can provide the classes. In short, the middleware gets the cookie and adds it to the body so SimpleJWT can access it. This is needed because SimpleJWT only supports token and refresh in the body and not as cookies which is not ideal.
