### PR TITLE
Updates Test Configuration, Narrows Dependency Declaration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,45 +3,44 @@ orbs:
   docker: circleci/docker@0.6.0
 
 jobs:
-  test-django-3: &template
+  test:
     docker:
       - image: circleci/python:3.8.0
-    environment:
-      DJANGO_VERSION: 3.1
-      DRF: 3.11.1
     executor: docker/docker
     steps:
       - checkout
       - run:
-          command: pip install --user Django==$DJANGO_VERSION djangorestframework==$DRF
-          name: "Pip install version-specific Django + DRF"
+          command: pip install --user tox coverage coveralls
+          name: "Install Tox & Coverage"
       - run:
-          command: pip install --user -r dj_rest_auth/tests/requirements.pip
-          name: "Pip Install test requirements"
+          command: tox
+          name: "Run Tox on All Supported Django and Python Versions"
       - run:
           command: |
             mkdir -p test-results/
-            coverage run --source=dj_rest_auth setup.py test
-            coverage report
-          name: Test
+            tox -e coverage
+          name: "Generate Coverage Report"
       - run:
           command: COVERALLS_REPO_TOKEN=Q58WdUuZOi89XHyDeDsGE2lxUGQ2IfqP3 coveralls
-          name: Coverage
+          name: "Send results to Coveralls"
+      - store_test_results:
+          path: test-results/
+  build:
+    docker:
+      - image: circleci/python:3.8.0
+    executor: docker/docker
+    steps:
+      - checkout
       - run:
           command: python3 setup.py sdist
           name: Build
-      - store_test_results:
-          path: test-results/
       - store_artifacts:
           path: dist/
-  test-django-2:
-    <<: *template
-    environment:
-      DJANGO_VERSION: 2.2.10
-      DRF: 3.9
 
 workflows:
   main:
     jobs:
-      - test-django-3
-      - test-django-2
+      - test
+      - build:
+          requires:
+            - test

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Drop-in API endpoints for handling authentication securely in Django Rest Framew
 with SPAs (e.g React, Vue, Angular), and Mobile applications. 
 
 ## Requirements
-- Django 2 or 3.
+- Django 2 or 3 (<3.1)
 - Python 3
 
 ## Quick Setup

--- a/dj_rest_auth/__version__.py
+++ b/dj_rest_auth/__version__.py
@@ -1,7 +1,7 @@
 __title__ = 'dj-rest-auth'
 __description__ = 'Authentication and Registration in Django Rest Framework.'
 __url__ = 'http://github.com/jazzband/dj-rest-auth'
-__version__ = '1.1.2'
+__version__ = '2.0.0'
 __author__ = '@iMerica https://github.com/iMerica'
 __author_email__ = 'imichael@pm.me'
 __license__ = 'MIT'

--- a/dj_rest_auth/tests/requirements.pip
+++ b/dj_rest_auth/tests/requirements.pip
@@ -1,6 +1,6 @@
-django-allauth>=0.25.0
-responses>=0.5.0
+django-allauth==0.42.0
+responses==0.10.0
 flake8==2.4.0
 djangorestframework-simplejwt==4.4.0
-unittest-xml-reporting>=3.0.2
-coveralls>=1.11.1
+unittest-xml-reporting==3.0.2
+coveralls==1.11.1

--- a/setup.py
+++ b/setup.py
@@ -27,16 +27,16 @@ setup(
     keywords='django rest auth registration rest-framework django-registration api',
     zip_safe=False,
     install_requires=[
-        'Django>=2.0',
+        'Django>=2.0,<3.1',
         'djangorestframework>=3.7.0',
     ],
     extras_require={
-        'with_social': ['django-allauth>=0.25.0'],
+        'with_social': ['django-allauth>=0.40.0,<0.43.0'],
     },
     tests_require=[
         'unittest-xml-reporting>=3.0.2',
         'responses>=0.5.0',
-        'django-allauth>=0.25.0',
+        'django-allauth==0.40.0',
         'djangorestframework-simplejwt>=4.4.0 ',
         'coveralls>=1.11.1'
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -10,16 +10,16 @@
 [tox]
 skipsdist = true
 envlist =
-    python{3.5,3.6,3.7,3.8}-django22
-    python{3.6,3.7,3.8}-django31
+    python{3.5,3.6,3.7,3.8,3.9}-django2
+    python{3.6,3.7,3.8,3.9}-django3
 
 [testenv]
 commands =
     python ./runtests.py
 deps =
     -rdj_rest_auth/tests/requirements.pip
-    django22: Django>=2.2,<2.3
-    django31: Django>=3.1
+    django2: Django>=2.2,<2.3
+    django3: Django>=3.0,<3.1
 
 # Configuration for coverage and flake8 is being set in `./setup.cfg`
 [testenv:coverage]


### PR DESCRIPTION
## Summary
This change narrows the supported Django and Django-All-Auth versions, as many tests are failing in various combinations of the two.  Note: the tests are failing due to upstream dependencies, not new regressions in this package.

As a matter of caution, I've bumped the major version to signify the impact of the change.

## Changes
- Moves Circle CI build config to use Tox to test all combinations of supported Python and Django Versions in CI.
- Adds Python 3.9 tests to tox configuration
- Pins specific versions of test dependencies.
- Narrows extras require of all-auth to `django-allauth>=0.40.0,<0.43.0` 
- Updates README
- Bumps Major Version
