### PR TITLE
pass id_token for parsing tokens

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -116,7 +116,7 @@ class SocialLoginSerializer(serializers.Serializer):
             tokens_to_parse = {'access_token': access_token}
 
             # If available we add additional data to the dictionary
-            for key in ["refresh_token", adapter.expires_in_key]:
+            for key in ["refresh_token", "id_token", adapter.expires_in_key]:
                 if key in token:
                     tokens_to_parse[key] = token[key]
         else:


### PR DESCRIPTION
I try to implement sign in with apple, and it needs id_token to parsing.

Bellow is my sample code
```
from allauth.socialaccount.providers.apple.views import AppleOAuth2Adapter
from allauth.socialaccount.providers.apple.client import AppleOAuth2Client

from dj_rest_auth.registration.views import SocialLoginView

class AppleLogin(SocialLoginView):
    client_class = AppleOAuth2Client
    callback_url = 'https://localhost:8000/accounts/apple/login/callback/'

    adapter_class = AppleOAuth2Adapter
```