### PR TITLE
Fix failure to delete jwt cookie on logout

### DIFF
--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -184,11 +184,34 @@ class LogoutView(APIView):
             from rest_framework_simplejwt.tokens import RefreshToken
 
             cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
-            if cookie_name:
-                response.delete_cookie(cookie_name)
             refresh_cookie_name = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE', None)
+            refresh_cookie_path = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE_PATH', '/')
+            cookie_secure = getattr(settings, 'JWT_AUTH_SECURE', False)
+            cookie_httponly = getattr(settings, 'JWT_AUTH_HTTPONLY', True)
+            cookie_samesite = getattr(settings, 'JWT_AUTH_SAMESITE', 'Lax')
+
+            if cookie_name:
+                response.set_cookie(
+                    cookie_name,
+                    # self.access_token,
+                    max_age=0,
+                    expires='Thu, 01 Jan 1970 00:00:00 GMT',
+                    secure=cookie_secure,
+                    httponly=cookie_httponly,
+                    samesite=cookie_samesite
+                )
+
             if refresh_cookie_name:
-                response.delete_cookie(refresh_cookie_name)
+                response.set_cookie(
+                    refresh_cookie_name,
+                    # self.refresh_token,
+                    max_age=0,
+                    expires='Thu, 01 Jan 1970 00:00:00 GMT',
+                    secure=cookie_secure,
+                    httponly=cookie_httponly,
+                    samesite=cookie_samesite,
+                    path=refresh_cookie_path
+                )
 
             if 'rest_framework_simplejwt.token_blacklist' in settings.INSTALLED_APPS:
                 # add refresh token to blacklist
@@ -211,7 +234,7 @@ class LogoutView(APIView):
                         response.data = {"detail": _("An error has occurred.")}
                         response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
 
-            else:
+            elif not cookie_name:
                 message = _(
                     "Neither cookies or blacklist are enabled, so the token "
                     "has not been deleted server side. Please make sure the token is deleted client side."


### PR DESCRIPTION
For some reason the jwt cookie is not being deleted on logout. 
From what I could gather it is because `response.delete_cookie()` is not generating the same cookie as the dj_rest_auth login view (differing httponly and samesite values). 
This has been fixed and does not break any of the existing tests (run on tox)

Also fixed issue where "Neither cookies nor..." message was being sent even when jwt_cookie is set 