### PR TITLE
Use drf-yasg for demo project

### DIFF
--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -42,7 +42,7 @@ INSTALLED_APPS = (
     'dj_rest_auth.registration',
     'allauth.socialaccount',
     'allauth.socialaccount.providers.facebook',
-    'rest_framework_swagger',
+    'drf_yasg',
     'corsheaders'
 )
 

--- a/demo/demo/urls.py
+++ b/demo/demo/urls.py
@@ -1,7 +1,15 @@
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic import RedirectView, TemplateView
-from rest_framework_swagger.views import get_swagger_view
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title='API Docs',
+        default_version='v1',
+    )
+)
 
 urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name="home.html"), name='home'),
@@ -39,5 +47,5 @@ urlpatterns = [
     url(r'^account/', include('allauth.urls')),
     url(r'^admin/', admin.site.urls),
     url(r'^accounts/profile/$', RedirectView.as_view(url='/', permanent=True), name='profile-redirect'),
-    url(r'^docs/$', get_swagger_view(title='API Docs'), name='api_docs')
+    url(r'^docs/$', schema_view.with_ui('swagger', cache_timeout=0), name='api_docs')
 ]

--- a/demo/requirements.pip
+++ b/demo/requirements.pip
@@ -3,6 +3,6 @@ dj-rest-auth @ git+https://github.com/jazzband/dj-rest-auth.git@master
 djangorestframework>=3.11.0
 djangorestframework-simplejwt==4.4.0
 django-allauth>=0.24.1
-django-rest-swagger==2.0.7
+drf-yasg==1.20.0
 django-cors-headers==3.2.1
 coreapi==2.3.3


### PR DESCRIPTION
Previously on the demo project, `/docs` raise an error caused by [`django-rest-swagger`](https://github.com/marcgibbons/django-rest-swagger) ([related issue](https://github.com/marcgibbons/django-rest-swagger/issues/832)). And since the project is no longer maintained, we can use [`drf-yasg`](https://github.com/axnsan12/drf-yasg) as its alternative (as mentioned on the repo).